### PR TITLE
Consertando todos os erros do calcular arredor

### DIFF
--- a/projPROLOG/matriz.pl
+++ b/projPROLOG/matriz.pl
@@ -12,19 +12,21 @@
 
 %A passagem de valor é do tipo In and Out, portanto, modificando o valor de R
 %dentro da função, também será mudado fora
-lugar1D(I, R) :- 
+lugar1D(I, R) :-
 	%Criando uma variavel local com a "matriz" do campo
 	Campo = [0, 1, 0, 0, 0, 1, 1, 0, 0],
 	%Isso é um if-else: (exp -> exp == true ; exp == false).
 	(I > -1, I < 9 ->
 		nth0(I, Campo, R)
-	; 	R is 0
-	).
+	; 	R is 0).
 
 
 lugar(Linha, Coluna, R) :-
 	%Só o is permite setar variaveis com alguma artimetica envolvida
-	Pos is 3 * Linha + Coluna,
+  (Linha > -1, Linha < 3, Coluna > -1, Coluna < 3->
+	   Pos is 3 * Linha + Coluna
+  ; Pos is -1
+  ),
 	%Repassando R
 	lugar1D(Pos, R).
 
@@ -35,47 +37,51 @@ eh_mina1D(Pos) :-
 	%Verifica se R é igual a 1, se sim, retorna true
 	R == 1.
 
-eh_mina(Linha, Coluna) :- 
-	Pos is 3 * Linha + Coluna,
+eh_mina(Linha, Coluna) :-
+  (Linha > -1, Linha < 3, Coluna > -1, Coluna < 3 ->
+	   Pos is 3 * Linha + Coluna
+  ; Pos is -1
+  ),
+
 	eh_mina1D(Pos).
 
 
 %X e Y são variaveis de entrada e Contagem de saida que vai ter o numero de minas
 %nos 8 campos ao redor do ponto de linha Y e coluna X da matriz
 conta_arredor(X, Y, Contagem) :-
-	NX is X - 1,
-	NY is Y - 1,
-	lugar(NY, NX, R1),
+	NX is X+1,
+	NY is Y+1,
+	lugar(NX, NY, R1),
 
 	%Ficar setando a mesma variavel com valores diferente varias vezes
 	%me causou problemas, ai criei novas
 	NX1 is X,
-	NY1 is Y - 1,
-	lugar(NY1, NX1, R2),
+	NY1 is Y-1,
+	lugar(NX1, NY1, R2),
 
-	NX2 is X + 1,
-	NY2 is Y - 1,
-	lugar(NY2, NX2, R3),
+	NX2 is X,
+	NY2 is Y+1,
+	lugar(NX2, NY2, R3),
 
-	NX3 is X + 1,
-	NY3 is Y,
-	lugar(NY3, NX3, R4),
+	NX3 is X-1,
+	NY3 is Y-1,
+	lugar(NX3, NY3, R4),
 
-	NX4 is X + 1,
-	NY4 is Y + 1,
-	lugar(NY4, NX4, R5),
+	NX4 is X-1,
+	NY4 is Y,
+	lugar(NX4, NY4, R5),
 
-	NX5 is X,
-	NY5 is Y + 1,
-	lugar(NY5, NX5, R6),
+	NX5 is X-1,
+	NY5 is Y+1,
+	lugar(NX5, NY5, R6),
 
-	NX6 is X - 1,
-	NY6 is Y + 1,
-	lugar(NY6, NX6, R7),
+	NX6 is X+1,
+	NY6 is Y-1,
+	lugar(NX6, NY6, R7),
 
-	NX7 is X - 1,
+	NX7 is X+1,
 	NY7 is Y,
-	lugar(NY7, NX7, R8),
+	lugar(NX7, NY7, R8),
 
 	%Como R[N] é criado dinamicamente, basta somar tudo e por em contagem que
 	%veio no parametro
@@ -86,4 +92,3 @@ conta_arredor(X, Y, Contagem) :-
 %Acima deve ser 3
 %eh_mina(1, 2).
 %Acima deve ser true
-


### PR DESCRIPTION
Tava trocado linhas por colunas no calcular arredores, e sem checar se linha ou coluna estavam fora da matriz, algumas vezes mesmo com coluna negativa conseguia um índice válido. Ex: Linha(2)*3 + -1 = 5 (índice válido), mas não existe a coluna -1.